### PR TITLE
fix: encode url filename

### DIFF
--- a/src/providers/GoogleCloudStorage.ts
+++ b/src/providers/GoogleCloudStorage.ts
@@ -1,11 +1,11 @@
-import { Inject, Injectable } from '@nestjs/common';
-import { STORAGE_CONFIG } from '../constants/providerNames';
-import { GoogleCloudConfigDto } from '../dtos/googleCloudConfig.dto';
-import { StorageInterface } from '../interfaces/storage.interface';
-import { Storage } from '@google-cloud/storage';
-import { UploadFileDto } from '../dtos/uploadFile.dto';
-import { DeleteFileDto } from '../dtos/deleteFile.dto';
-import { StorageConfigDto } from '../dtos/storageConfig.dto';
+import { Inject, Injectable } from "@nestjs/common";
+import { STORAGE_CONFIG } from "../constants/providerNames";
+import { GoogleCloudConfigDto } from "../dtos/googleCloudConfig.dto";
+import { StorageInterface } from "../interfaces/storage.interface";
+import { Storage } from "@google-cloud/storage";
+import { UploadFileDto } from "../dtos/uploadFile.dto";
+import { DeleteFileDto } from "../dtos/deleteFile.dto";
+import { StorageConfigDto } from "../dtos/storageConfig.dto";
 
 @Injectable()
 export class GoogleCloudStorage implements StorageInterface {
@@ -15,8 +15,8 @@ export class GoogleCloudStorage implements StorageInterface {
     @Inject(STORAGE_CONFIG)
     private readonly storageConfig: StorageConfigDto
   ) {
-    this.googleCloudConfig = this.storageConfig.gcp
-    
+    this.googleCloudConfig = this.storageConfig.gcp;
+
     if (this.googleCloudConfig.credentialsKeyPath) {
       this.storage = new Storage({
         projectId: this.googleCloudConfig.projectId,
@@ -44,19 +44,21 @@ export class GoogleCloudStorage implements StorageInterface {
           resumable: false,
         });
 
-        stream.on('error', reject);
+        stream.on("error", reject);
 
-        stream.on('finish', async () => {
+        stream.on("finish", async () => {
           remoteFile.makePublic().then(() => {
             resolve(
-              `https://storage.googleapis.com/${this.googleCloudConfig.bucket}/${_filename}`
+              `https://storage.googleapis.com/${
+                this.googleCloudConfig.bucket
+              }/${encodeURI(_filename)}`
             );
           });
         });
 
         stream.end(buffer);
       } catch (err) {
-        console.error('Error trying to upload a file');
+        console.error("Error trying to upload a file");
         console.error(err);
       }
     });

--- a/src/providers/GoogleCloudStorage.ts
+++ b/src/providers/GoogleCloudStorage.ts
@@ -35,7 +35,8 @@ export class GoogleCloudStorage implements StorageInterface {
   }: UploadFileDto): Promise<string> {
     return new Promise(async (resolve, reject) => {
       try {
-        const _filename = path ? `${path}/${filename}` : filename;
+        const encodedFilename = encodeURIComponent(filename);
+        const _filename = path ? `${path}/${encodedFilename}` : encodedFilename;
         const bucket = this.storage.bucket(this.googleCloudConfig.bucket);
         const remoteFile = bucket.file(_filename);
 
@@ -49,9 +50,7 @@ export class GoogleCloudStorage implements StorageInterface {
         stream.on("finish", async () => {
           remoteFile.makePublic().then(() => {
             resolve(
-              `https://storage.googleapis.com/${
-                this.googleCloudConfig.bucket
-              }/${encodeURIComponent(_filename)}`
+              `https://storage.googleapis.com/${this.googleCloudConfig.bucket}/${_filename}`
             );
           });
         });

--- a/src/providers/GoogleCloudStorage.ts
+++ b/src/providers/GoogleCloudStorage.ts
@@ -51,7 +51,7 @@ export class GoogleCloudStorage implements StorageInterface {
             resolve(
               `https://storage.googleapis.com/${
                 this.googleCloudConfig.bucket
-              }/${encodeURI(_filename)}`
+              }/${encodeURIComponent(_filename)}`
             );
           });
         });


### PR DESCRIPTION
- Fixed an issue where naming files with symbols like "!", "#" etc would cause the returned link to be invalid

Example:
filename: Yellow#10
- Returned value: https://storage.googleapis.com/poe-staging/nft-randomizer/1cf655a6-55b6-41f0-8982-ab1e714e545f/input/Yellow#10af475eb88704a6e870ab.png
- Expected value: https://storage.googleapis.com/poe-staging/nft-randomizer/1cf655a6-55b6-41f0-8982-ab1e714e545f/input/Yellow%2310af475eb88704a6e870ab.png